### PR TITLE
Add setup.py for installation as python app

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,20 @@
+from setuptools import setup
+
+setup(
+    name='svg2obj',
+    version='0.1',
+    author='Teseo Schneider',
+    description='Convert SVG files to OBJ',
+    url='https://github.com/teseoch/svg2obj',
+    packages=['svgpathtools', 'svgpathtools.svgpathtools'],
+    py_modules=['svg2obj', 'parse_svg', 'RationalBezier'],
+    entry_points={
+        'console_scripts': [
+            'svg2obj = svg2obj:main',
+        ],
+    },
+    install_requires=[
+        'numpy',
+        'svgwrite',
+    ]
+)

--- a/svg2obj.py
+++ b/svg2obj.py
@@ -1,0 +1,10 @@
+from parse_svg import convert_svg, parse_args
+
+
+def main():
+    args = parse_args()
+    convert_svg(args.image, args.output)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I wrote a `setup.py` file so that you can install `svg2obj` as a Python command line app with e.g. `python3 -m pipx install svg2obj/` from the parent directory (`git submodule update --init --recursive` is still required beforehand). Afterwards, the tool can be run from anywhere by just calling `svg2obj` which might be handy for certain workflows. Feel free to make suggestions are deny the pull request if you don't like this functionality.